### PR TITLE
fix(test): improve test for write contract

### DIFF
--- a/packages/modules/token/src/actions/__tests__/deployInfinitERC20Burnable.test.ts
+++ b/packages/modules/token/src/actions/__tests__/deployInfinitERC20Burnable.test.ts
@@ -1,24 +1,20 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
+import { encodeFunctionData } from 'viem'
 import { Address, privateKeyToAccount } from 'viem/accounts'
-import { arbitrum } from 'viem/chains'
-
-import { InfinitWallet } from '@infinit-xyz/core'
 
 import { ANVIL_PRIVATE_KEY } from '@actions/__mocks__/account'
 import { TEST_ADDRESSES } from '@actions/__mocks__/address'
 import { DeployInfinitERC20BurnableAction } from '@actions/deployInfinitERC20Burnable'
 
-import { TestChain, TestInfinitWallet, getForkRpcUrl } from '@infinit-xyz/test'
+import { TestChain, TestInfinitWallet } from '@infinit-xyz/test'
 import { readArtifact } from '@utils/artifact'
 
 describe('deployInfinitERC20BurnableBurnableAction', () => {
   let action: DeployInfinitERC20BurnableAction
-  let client: InfinitWallet
-  let bobClient: InfinitWallet
+  let client: TestInfinitWallet
+  let bobClient: TestInfinitWallet
 
-  // anvil rpc endpoint
-  const rpcEndpoint = getForkRpcUrl(TestChain.arbitrum)
   const bob = TEST_ADDRESSES.bob
   // anvil tester pk
   const privateKey = ANVIL_PRIVATE_KEY
@@ -26,7 +22,7 @@ describe('deployInfinitERC20BurnableBurnableAction', () => {
   beforeAll(() => {
     const account = privateKeyToAccount(privateKey)
     bobClient = new TestInfinitWallet(TestChain.arbitrum, bob)
-    client = new InfinitWallet(arbitrum, rpcEndpoint, account)
+    client = new TestInfinitWallet(TestChain.arbitrum, account.address)
   })
 
   test('deploy token, owner is deployer', async () => {
@@ -86,12 +82,20 @@ describe('deployInfinitERC20BurnableBurnableAction', () => {
       args: [client.walletClient.account.address],
     })
 
-    await client.walletClient.writeContract({
-      address: ttToken,
-      abi: infinitERC20.abi,
-      functionName: 'mint',
-      args: [client.walletClient.account.address, mintAmount],
-    })
+    await client.sendTransactions([
+      {
+        name: 'mint',
+        txData: {
+          to: ttToken,
+          data: encodeFunctionData({
+            abi: infinitERC20.abi,
+            functionName: 'mint',
+            args: [client.walletClient.account.address, mintAmount],
+          }),
+        },
+      },
+    ])
+
     const balanceAfterMint = await client.publicClient.readContract({
       address: ttToken,
       abi: infinitERC20.abi,
@@ -182,17 +186,22 @@ describe('deployInfinitERC20BurnableBurnableAction', () => {
 
     const mintAmount = BigInt(100000000000000000000000)
 
-    try {
-      // Attempt to mint tokens as a non-owner
-      await bobClient.walletClient.writeContract({
-        address: ttToken,
-        abi: infinitERC20.abi,
-        functionName: 'mint',
-        args: [bob, mintAmount],
-      })
-    } catch (e) {
-      expect(e).not.toBeUndefined()
-    }
+    // Attempt to mint tokens as a non-owner
+    await expect(
+      bobClient.sendTransactions([
+        {
+          name: 'mint',
+          txData: {
+            to: ttToken,
+            data: encodeFunctionData({
+              abi: infinitERC20.abi,
+              functionName: 'mint',
+              args: [bob, mintAmount],
+            }),
+          },
+        },
+      ]),
+    ).rejects.toThrowError()
   })
 
   // test deploy token, test burn token
@@ -223,12 +232,20 @@ describe('deployInfinitERC20BurnableBurnableAction', () => {
       functionName: 'balanceOf',
       args: [client.walletClient.account.address],
     })
-    await client.walletClient.writeContract({
-      address: ttToken,
-      abi: infinitERC20.abi,
-      functionName: 'burn',
-      args: [burnAmount],
-    })
+
+    await client.sendTransactions([
+      {
+        name: 'burn',
+        txData: {
+          to: ttToken,
+          data: encodeFunctionData({
+            abi: infinitERC20.abi,
+            functionName: 'burn',
+            args: [burnAmount],
+          }),
+        },
+      },
+    ])
     const balanceAfterBurn = await client.publicClient.readContract({
       address: ttToken,
       abi: infinitERC20.abi,

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -10,10 +10,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    },
-    "./actions": {
-      "types": "./dist/actions/index.d.ts",
-      "default": "./dist/actions/index.js"
     }
   },
   "scripts": {

--- a/packages/test/src/testInfinitWallet.ts
+++ b/packages/test/src/testInfinitWallet.ts
@@ -1,8 +1,8 @@
-import type { Address, Client, Hash, Hex, TestActions, TransactionReceipt, WalletActions } from 'viem'
+import type { Address, Client, Hash, TestActions, TransactionReceipt, WalletActions } from 'viem'
 import { parseEther, walletActions } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
-import { InfinitWallet, ToSendTransaction } from '@infinit-xyz/core'
+import { ActionCallback, InfinitWallet, ToSendTransaction } from '@infinit-xyz/core'
 import { TransactionError } from '@infinit-xyz/core/errors'
 
 import { testClients } from './client.js'
@@ -26,7 +26,7 @@ export class TestInfinitWallet extends InfinitWallet {
     this.impersonatedUser = impersonatedUser
   }
 
-  override sendTransactions = async (transactions: ToSendTransaction[]): Promise<TransactionReceipt[]> => {
+  override sendTransactions = async (transactions: ToSendTransaction[], callback?: ActionCallback): Promise<TransactionReceipt[]> => {
     await this.testClient.impersonateAccount({
       address: this.impersonatedUser,
     })
@@ -37,27 +37,40 @@ export class TestInfinitWallet extends InfinitWallet {
       value: parseEther('100'),
     })
 
-    const txHashes: Hex[] = []
-    // 1. Submit all transactions
-    for (const transaction of transactions) {
-      const tx = transaction.txData
-      const hash: Hash = await this.testClient.sendTransaction({
-        account: this.impersonatedUser,
-        to: tx.to,
-        value: tx.value,
-        data: tx.data,
-        chain: this.publicClient.chain,
-      })
-      if (!(await this.checkTransaction(hash))) throw new TransactionError(hash)
-      txHashes.push(hash)
-    }
+    const txReceipts: TransactionReceipt[] = []
 
-    // 2. get transaction receipts
-    const txReceipts = await Promise.all(txHashes.map((txHash) => this.publicClient.getTransactionReceipt({ hash: txHash })))
+    for (const transaction of transactions) {
+      const walletAddress = this.impersonatedUser
+      // Send the transaction using the wallet client and get the transaction hash
+      const txHash: Hash = await this.walletClient.sendTransaction({
+        ...transaction.txData,
+        account: this.impersonatedUser,
+        chain: this.walletClient.chain,
+      })
+
+      // Notify the callback that the transaction has been submitted
+      await callback?.('txSubmitted', { name: transaction.name, txHash, walletAddress })
+
+      // Wait for the transaction to be confirmed and get the receipt
+      const txReceipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash })
+
+      // Check if the transaction was successful; throw an error if not
+      if (txReceipt.status !== 'success') {
+        console.log(`txReceipt.status !== 'success'`)
+        throw new TransactionError(txHash)
+      }
+
+      // Notify the callback that the transaction has been confirmed
+      await callback?.('txConfirmed', { name: transaction.name, txHash, walletAddress })
+
+      // Add the transaction receipt to the array of receipts
+      txReceipts.push(txReceipt)
+    }
 
     await this.testClient.stopImpersonatingAccount({
       address: this.impersonatedUser,
     })
+
     return txReceipts
   }
 }

--- a/packages/test/src/testInfinitWallet.ts
+++ b/packages/test/src/testInfinitWallet.ts
@@ -56,7 +56,6 @@ export class TestInfinitWallet extends InfinitWallet {
 
       // Check if the transaction was successful; throw an error if not
       if (txReceipt.status !== 'success') {
-        console.log(`txReceipt.status !== 'success'`)
         throw new TransactionError(txHash)
       }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     poolOptions: {
       threads: {
         minThreads: 1,
-        maxThreads: 4,
+        maxThreads: 8,
       },
     },
     globals: true,


### PR DESCRIPTION
Problem: when use `writeContract`, it just submit the contract without waiting for the transaction receipt so sometimes the code continue before the transaction is even being confirmed.
Fix: Migrate to use the `InfinitWallet's sendTransactions` instead.